### PR TITLE
deps: Update upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,7 +27,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build-storybook
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: storybook-static
   


### PR DESCRIPTION
Update upload-pages-artifact to v3 because v1 is deprecated.