### PR TITLE
ci: add config for semantic pr app

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,24 @@
+# Semantic Commit bot: https://github.com/Ezard/semantic-prs
+
+# Validate the PR title, and ignore all commit messages
+titleOnly: true
+
+# The values allowed for the "type" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+
+# The values allowed for the "scope" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat(awesome-feature): add some stuff", the type would be "awesome-feature"
+scopes: # default: any value
+  - deps


### PR DESCRIPTION
The [semantic PR app](https://github.com/Ezard/semantic-prs) can be configured, so the `semantic.yml` is added in this PR.
It configures the following things:

- Only PR title is checked
- List of allowed types
- List of allowed scopes