### PR TITLE
ci: remove build step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-      - run: npm run build
       - name: semantic release
         uses: cycjimmy/semantic-release-action@v3
         env:


### PR DESCRIPTION
Remove build step from npm publish because we currently do not have a build action defined.