### PR TITLE
ci: remove build step and upgrade semantic release to v5

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - name: semantic release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remove build step because currently we do not have a build action defined.
Upgrade `cycjimmy/semantic-release-action` to v5.