### PR TITLE
ci: give write permissions for semantic release action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The `cycjimmy/semantic-release-action` pushes tags to the repository, therefore write permissions are needed to do so.