### PR TITLE
chore: update publish-npm workflow with write permissions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,6 +5,10 @@ on:
       - main # only run on main branch
   workflow_dispatch:
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Replace invalid npm Token. Now Github is a Trusted Publisher for our npm Package. 