### PR TITLE
chore: removed unused env from publish npm action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,8 +27,4 @@ jobs:
       - name: Build project
         run: npm run build --if-present
       - name: Release with semantic-release
-        env:
-          HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Removed unused env section from  npm token from publish-npm action.